### PR TITLE
Reject malformed include mechanism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ executors:
       ruby-version:
         description: Ruby version to use, passed in as a string
         type: string
-        default: "2.7"
+        default: "3.0"
 
     docker:
       - image: cimg/ruby:<< parameters.ruby-version >>

--- a/Gemfile
+++ b/Gemfile
@@ -5,13 +5,17 @@ gemspec
 
 group :development, :test do
   gem 'brakeman', require: false
+  gem 'rspec', '>= 3.0'
   gem 'rubocop', require: false
   gem 'rubocop-rake', require: false
   gem 'rubocop-rspec', require: false
 end
 
 group :test do
+  gem 'bundler'
   gem 'codecov', require: false
+  gem 'flay'
+  gem 'rake', '~> 13.0'
   gem 'rspec_junit_formatter'
   gem 'simplecov'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -59,7 +59,7 @@ end
 def escape_quote(val)
   return unless val
 
-  val.gsub(/'/) { |_s| "\\'" }
+  val.gsub("'") { |_s| "\\'" }
 end
 
 def clean_description(description)
@@ -84,8 +84,8 @@ end
 
 def write_result(f, host, mailfrom, helo, indent)
   spf_result =
-    "Coppertone::SpfService.authenticate_email('#{host}', '#{mailfrom}'," \
-    " '#{helo}', options)"
+    "Coppertone::SpfService.authenticate_email('#{host}', '#{mailfrom}', " \
+    "'#{helo}', options)"
   puts_prefixed_string(f, "result = #{spf_result}", indent)
 end
 

--- a/coppertone.gemspec
+++ b/coppertone.gemspec
@@ -13,16 +13,11 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.7'
 
-  spec.add_runtime_dependency 'activesupport', '>= 3.0'
-  spec.add_runtime_dependency 'addressable'
-  spec.add_runtime_dependency 'dns_adapter'
-  spec.add_runtime_dependency 'i18n'
-  spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'flay'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '>= 3.0'
+  spec.add_dependency 'activesupport', '>= 3.0'
+  spec.add_dependency 'addressable'
+  spec.add_dependency 'dns_adapter'
+  spec.add_dependency 'i18n'
 end

--- a/lib/coppertone/mechanism.rb
+++ b/lib/coppertone/mechanism.rb
@@ -26,6 +26,14 @@ module Coppertone
       false
     end
 
+    def self.missing_required_initial_colon?(attributes)
+      requires_initial_colon? && attributes.to_s !~ /\A\:/
+    end
+
+    def self.requires_initial_colon?
+      false
+    end
+
     attr_reader :arguments
 
     def initialize(arguments)

--- a/lib/coppertone/mechanism.rb
+++ b/lib/coppertone/mechanism.rb
@@ -27,7 +27,7 @@ module Coppertone
     end
 
     def self.missing_required_initial_colon?(attributes)
-      requires_initial_colon? && attributes.to_s !~ /\A\:/
+      requires_initial_colon? && attributes.to_s !~ /\A:/
     end
 
     def self.requires_initial_colon?

--- a/lib/coppertone/mechanism/domain_spec_optional.rb
+++ b/lib/coppertone/mechanism/domain_spec_optional.rb
@@ -9,7 +9,7 @@ module Coppertone
       end
 
       def initialize(attributes)
-        super(attributes)
+        super
         return if attributes.blank?
 
         raw_domain_spec = trim_domain_spec(attributes)

--- a/lib/coppertone/mechanism/domain_spec_required.rb
+++ b/lib/coppertone/mechanism/domain_spec_required.rb
@@ -9,7 +9,7 @@ module Coppertone
       def initialize(attributes)
         raise InvalidMechanismError if self.class.missing_required_initial_colon?(attributes)
 
-        super(attributes)
+        super
         raw_domain_spec = trim_domain_spec(attributes)
         raise InvalidMechanismError if raw_domain_spec.blank?
 

--- a/lib/coppertone/mechanism/domain_spec_required.rb
+++ b/lib/coppertone/mechanism/domain_spec_required.rb
@@ -7,6 +7,8 @@ module Coppertone
       end
 
       def initialize(attributes)
+        raise InvalidMechanismError if self.class.missing_required_initial_colon?(attributes)
+
         super(attributes)
         raw_domain_spec = trim_domain_spec(attributes)
         raise InvalidMechanismError if raw_domain_spec.blank?

--- a/lib/coppertone/mechanism/domain_spec_with_dual_cidr.rb
+++ b/lib/coppertone/mechanism/domain_spec_with_dual_cidr.rb
@@ -111,7 +111,7 @@ module Coppertone
       alias eql? ==
 
       def hash
-        domain_spec.hash ^ ip_v4_cidr_length.hash ^ ip_v6_cidr_length.hash
+        [domain_spec, ip_v4_cidr_length, ip_v6_cidr_length].hash
       end
     end
   end

--- a/lib/coppertone/mechanism/domain_spec_with_dual_cidr.rb
+++ b/lib/coppertone/mechanism/domain_spec_with_dual_cidr.rb
@@ -12,7 +12,7 @@ module Coppertone
       end
 
       def initialize(attributes)
-        super(attributes)
+        super
         return if attributes.blank?
 
         parse_argument(attributes)

--- a/lib/coppertone/mechanism/exists.rb
+++ b/lib/coppertone/mechanism/exists.rb
@@ -12,6 +12,10 @@ module Coppertone
       def self.label
         'exists'
       end
+
+      def self.requires_initial_colon?
+        true
+      end
     end
     register(Coppertone::Mechanism::Exists)
   end

--- a/lib/coppertone/mechanism/include.rb
+++ b/lib/coppertone/mechanism/include.rb
@@ -24,6 +24,10 @@ module Coppertone
       def self.label
         'include'
       end
+
+      def self.requires_initial_colon?
+        true
+      end
     end
     register(Coppertone::Mechanism::Include)
   end

--- a/lib/coppertone/mechanism/ip4.rb
+++ b/lib/coppertone/mechanism/ip4.rb
@@ -11,6 +11,10 @@ module Coppertone
       def self.label
         'ip4'
       end
+
+      def self.requires_initial_colon?
+        true
+      end
     end
     register(Coppertone::Mechanism::IP4)
   end

--- a/lib/coppertone/mechanism/ip6.rb
+++ b/lib/coppertone/mechanism/ip6.rb
@@ -11,6 +11,10 @@ module Coppertone
       def self.label
         'ip6'
       end
+
+      def self.requires_initial_colon?
+        true
+      end
     end
     register(Coppertone::Mechanism::IP6)
   end

--- a/lib/coppertone/mechanism/ip_mechanism.rb
+++ b/lib/coppertone/mechanism/ip_mechanism.rb
@@ -9,6 +9,8 @@ module Coppertone
       end
 
       def initialize(attributes)
+        raise InvalidMechanismError if self.class.missing_required_initial_colon?(attributes)
+
         super(attributes)
         unless attributes.blank?
           attributes = attributes[1..] if attributes[0] == ':'

--- a/lib/coppertone/mechanism/ip_mechanism.rb
+++ b/lib/coppertone/mechanism/ip_mechanism.rb
@@ -11,7 +11,7 @@ module Coppertone
       def initialize(attributes)
         raise InvalidMechanismError if self.class.missing_required_initial_colon?(attributes)
 
-        super(attributes)
+        super
         unless attributes.blank?
           attributes = attributes[1..] if attributes[0] == ':'
           @netblock, @cidr_length = parse_netblock(attributes)

--- a/lib/coppertone/modifier/base.rb
+++ b/lib/coppertone/modifier/base.rb
@@ -5,7 +5,7 @@ module Coppertone
       attr_reader :domain_spec
 
       def initialize(attributes)
-        super(attributes)
+        super
         raise InvalidModifierError if attributes.blank?
 
         @domain_spec = Coppertone::DomainSpec.new(attributes)

--- a/lib/coppertone/record.rb
+++ b/lib/coppertone/record.rb
@@ -90,7 +90,7 @@ module Coppertone
       [Coppertone::Modifier::Exp, Coppertone::Modifier::Redirect].freeze
     def unknown_modifiers
       @unknown_modifiers ||=
-        modifiers.select { |m| KNOWN_MODS.select { |k| m.is_a?(k) }.empty? }
+        modifiers.select { |m| KNOWN_MODS.none? { |k| m.is_a?(k) } }
     end
 
     def find_modifier(klass)

--- a/spec/directive_spec.rb
+++ b/spec/directive_spec.rb
@@ -24,7 +24,7 @@ describe Coppertone::Directive do
       expect(directive.qualifier).to eq(Coppertone::Qualifier::FAIL)
       mechanism = directive.mechanism
       expect(mechanism).not_to be_nil
-      expect(mechanism).to eq(Coppertone::Mechanism::IP4.new('192.1.1.1'))
+      expect(mechanism).to eq(Coppertone::Mechanism::IP4.new(':192.1.1.1'))
     end
   end
 

--- a/spec/mechanism/exists_spec.rb
+++ b/spec/mechanism/exists_spec.rb
@@ -14,6 +14,12 @@ describe Coppertone::Mechanism::Exists do
       end.to raise_error(Coppertone::InvalidMechanismError)
     end
 
+    it 'should fail if called with an argument that is missing a leading colon' do
+      expect do
+        Coppertone::Mechanism::Exists.new('_spf.example.com')
+      end.to raise_error(Coppertone::InvalidMechanismError)
+    end
+
     it 'should fail if called with an invalid macrostring' do
       expect do
         Coppertone::Mechanism::Exists.new(':abc%:def')

--- a/spec/mechanism/include_spec.rb
+++ b/spec/mechanism/include_spec.rb
@@ -14,6 +14,12 @@ describe Coppertone::Mechanism::Include do
       end.to raise_error(Coppertone::InvalidMechanismError)
     end
 
+    it 'should fail if called with an argument that is missing a leading colon' do
+      expect do
+        Coppertone::Mechanism::Include.new('_spf.example.com')
+      end.to raise_error(Coppertone::InvalidMechanismError)
+    end
+
     it 'should fail if called with an invalid macrostring' do
       expect do
         Coppertone::Mechanism::Include.new(':abc%:def')

--- a/spec/mechanism/ip4_spec.rb
+++ b/spec/mechanism/ip4_spec.rb
@@ -20,6 +20,12 @@ describe Coppertone::Mechanism::IP4 do
       end.to raise_error(Coppertone::InvalidMechanismError)
     end
 
+    it 'should fail if called with a valid IP v4 but no leading colon' do
+      expect do
+        Coppertone::Mechanism::IP4.new('1.2.3.4')
+      end.to raise_error(Coppertone::InvalidMechanismError)
+    end
+
     it 'should not fail if called with an IP v6' do
       mech = Coppertone::Mechanism::IP4.new(':fe80::202:b3ff:fe1e:8329')
       expect(mech.netblock).to eq(IPAddr.new('fe80::202:b3ff:fe1e:8329'))
@@ -28,6 +34,12 @@ describe Coppertone::Mechanism::IP4 do
       expect(mech).not_to be_includes_ptr
       expect(mech).not_to be_context_dependent
       expect(mech).not_to be_dns_lookup_term
+    end
+
+    it 'should fail if called with a valid IP v6 but no leading colon' do
+      expect do
+        Coppertone::Mechanism::IP4.new('fe80::202:b3ff:fe1e:8329')
+      end.to raise_error(Coppertone::InvalidMechanismError)
     end
 
     it 'should work if called with an IP4' do

--- a/spec/mechanism/ip6_spec.rb
+++ b/spec/mechanism/ip6_spec.rb
@@ -20,6 +20,12 @@ describe Coppertone::Mechanism::IP6 do
       end.to raise_error(Coppertone::InvalidMechanismError)
     end
 
+    it 'should fail if called with a valid IP without a leading colon' do
+      expect do
+        Coppertone::Mechanism::IP6.new('fe80::202:b3ff:fe1e:8329')
+      end.to raise_error(Coppertone::InvalidMechanismError)
+    end
+
     it 'should not fail if called with an IP v4' do
       mech = Coppertone::Mechanism::IP6.new(':1.2.3.4')
       expect(mech.netblock).to eq(IPAddr.new('1.2.3.4'))

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -94,6 +94,12 @@ describe Coppertone::Record do
       end.to raise_error(Coppertone::RecordParsingError)
     end
 
+    it 'should fail when it contains a typo that was probably intended to be an include mechanism' do
+      expect do
+        Coppertone::Record.new('v=spf1 include.spf.protection.outlook.com')
+      end.to raise_error(Coppertone::RecordParsingError)
+    end
+
     it 'should fail when it contains spurious terms' do
       expect do
         Coppertone::Record.new('v=spf1 ip4:1.2.3.4 -all moo')

--- a/spec/sender_identity_spec.rb
+++ b/spec/sender_identity_spec.rb
@@ -38,7 +38,7 @@ describe Coppertone::SenderIdentity do
 
   it 'should not raise an error if the sender has a too-long domain' do
     localpart = 'lymeeater'
-    domain = 'A123456789012345678901234567890123456789'\
+    domain = 'A123456789012345678901234567890123456789' \
              '012345678901234567890123.example.com'
     sender = "#{localpart}@#{domain}"
     si = Coppertone::SenderIdentity.new(sender)


### PR DESCRIPTION
We were failing to detect the syntax error in an SPF record that read:  `v=spf1 include.spf.protection.outlook.com`

(This was presumably intended to be `v=spf1 include:spf.protection.outlook.com`—note the colon after `include`).

[RFC 7208's grammar](https://datatracker.ietf.org/doc/html/rfc7208#section-12) indicates that the `exists`, `include`, `ip4`, and `ip6` mechanisms all require a colon after the mechanism label, so I've changed all four of the corresponding classes in this gem so that they will also reject arguments that are missing colons.