### PR TITLE
RFC 7208: 5.2, none result should be returned as "no match"

### DIFF
--- a/lib/coppertone/mechanism/include_matcher.rb
+++ b/lib/coppertone/mechanism/include_matcher.rb
@@ -10,12 +10,13 @@ module Coppertone
           result
         end
 
-        def evaluate_none_result(result, m, r)
-          new_result = super
-          return new_result unless new_result.none?
+        # RFC 7208: 5.2, none result should be returned as "no match"
+        # def evaluate_none_result(result, m, r)
+        #   new_result = super
+        #   return new_result unless new_result.none?
 
-          raise Coppertone::NoneIncludeResultError
-        end
+        #   raise Coppertone::NoneIncludeResultError
+        # end
       end
 
       attr_reader :record


### PR DESCRIPTION
When including an external SPF record with `include` the RFC explicitly allows the result to be empty (?all does not need to be present).

Currently when including an SPF record with only ip addresses and no `all` directive the validation will result in a `permerror`.

This PR removes the check and allows 'none' as a result.